### PR TITLE
Fix missing match-complete event from WaitingForLoad state

### DIFF
--- a/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHubContext.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHubContext.cs
@@ -335,7 +335,13 @@ namespace osu.Server.Spectator.Hubs.Multiplayer
                 }
             }
 
-            await ChangeRoomState(room, anyUserPlaying ? MultiplayerRoomState.Playing : MultiplayerRoomState.Open);
+            if (anyUserPlaying)
+                await ChangeRoomState(room, MultiplayerRoomState.Playing);
+            else
+            {
+                await ChangeRoomState(room, MultiplayerRoomState.Open);
+                await room.MatchTypeImplementation.HandleMatchComplete();
+            }
         }
 
         public async Task UpdateRoomStateIfRequired(ServerMultiplayerRoom room)


### PR DESCRIPTION
Probably not the best place to handle this but it'll do for now, I think.