### PR TITLE
Don't notify users of idle state when match is found

### DIFF
--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueue.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/Queue/MatchmakingQueue.cs
@@ -115,10 +115,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Queue
                     return bundle;
 
                 foreach (var u in user.Group.Users)
-                {
                     matchmakingUsers.Remove(u);
-                    bundle.RemovedUsers.Add(u);
-                }
 
                 bundle.CompletedGroups.Add(user.Group);
             }


### PR DESCRIPTION
Because of this, the client would intermittently show the "begin queueing" state, before shortly switching to the match state.

Client still handles fine due to this code: https://github.com/smoogipoo/osu/blob/6d43c0c7cfe0b4c299ec7f5f236d4e3aac488d2f/osu.Game/Screens/OnlinePlay/Matchmaking/MatchmakingController.cs#L63-L67