### PR TITLE
Hide playlist items from ranked play rooms

### DIFF
--- a/osu.Server.Spectator.Tests/Matchmaking/MatchmakingMatchControllerTests.cs
+++ b/osu.Server.Spectator.Tests/Matchmaking/MatchmakingMatchControllerTests.cs
@@ -46,7 +46,7 @@ namespace osu.Server.Spectator.Tests.Matchmaking
         public async Task InitializeAsync()
         {
             using (var room = await Rooms.GetForUse(ROOM_ID, true))
-                room.Item = await MatchmakingQueueBackgroundService.InitialiseRoomAsync(ROOM_ID, HubContext, DatabaseFactory.Object, EventLogger, 0, [USER_ID, USER_ID_2]);
+                room.Item = await MatchmakingQueueBackgroundService.InitialiseRoomAsync(ROOM_ID, HubContext, DatabaseFactory.Object, EventLogger, 0, [USER_ID, USER_ID_2], new MatchmakingBeatmapSelector([]));
         }
 
         [Fact]
@@ -202,7 +202,7 @@ namespace osu.Server.Spectator.Tests.Matchmaking
             CreateUser(3, out Mock<HubCallerContext> contextUser3, out _);
 
             using (var room = await Rooms.GetForUse(ROOM_ID, true))
-                room.Item = await MatchmakingQueueBackgroundService.InitialiseRoomAsync(ROOM_ID, HubContext, DatabaseFactory.Object, EventLogger, 0, [USER_ID, USER_ID_2, 3]);
+                room.Item = await MatchmakingQueueBackgroundService.InitialiseRoomAsync(ROOM_ID, HubContext, DatabaseFactory.Object, EventLogger, 0, [USER_ID, USER_ID_2, 3], new MatchmakingBeatmapSelector([]));
 
             await Hub.JoinRoom(ROOM_ID);
             SetUserContext(ContextUser2);
@@ -293,7 +293,7 @@ namespace osu.Server.Spectator.Tests.Matchmaking
             CreateUser(3, out Mock<HubCallerContext> contextUser3, out _);
 
             using (var room = await Rooms.GetForUse(ROOM_ID, true))
-                room.Item = await MatchmakingQueueBackgroundService.InitialiseRoomAsync(ROOM_ID, HubContext, DatabaseFactory.Object, EventLogger, 0, [USER_ID, USER_ID_2, 3]);
+                room.Item = await MatchmakingQueueBackgroundService.InitialiseRoomAsync(ROOM_ID, HubContext, DatabaseFactory.Object, EventLogger, 0, [USER_ID, USER_ID_2, 3], new MatchmakingBeatmapSelector([]));
 
             await Hub.JoinRoom(ROOM_ID);
 
@@ -327,7 +327,7 @@ namespace osu.Server.Spectator.Tests.Matchmaking
             CreateUser(3, out Mock<HubCallerContext> contextUser3, out _);
 
             using (var room = await Rooms.GetForUse(ROOM_ID, true))
-                room.Item = await MatchmakingQueueBackgroundService.InitialiseRoomAsync(ROOM_ID, HubContext, DatabaseFactory.Object, EventLogger, 0, [USER_ID, USER_ID_2, 3]);
+                room.Item = await MatchmakingQueueBackgroundService.InitialiseRoomAsync(ROOM_ID, HubContext, DatabaseFactory.Object, EventLogger, 0, [USER_ID, USER_ID_2, 3], new MatchmakingBeatmapSelector([]));
 
             await Hub.JoinRoom(ROOM_ID);
 
@@ -642,7 +642,7 @@ namespace osu.Server.Spectator.Tests.Matchmaking
             CreateUser(3, out var contextUser3, out _);
 
             using (var roomUsage = await Rooms.GetForUse(ROOM_ID, true))
-                roomUsage.Item = await MatchmakingQueueBackgroundService.InitialiseRoomAsync(ROOM_ID, HubContext, DatabaseFactory.Object, EventLogger, 0, [USER_ID, USER_ID_2, 3]);
+                roomUsage.Item = await MatchmakingQueueBackgroundService.InitialiseRoomAsync(ROOM_ID, HubContext, DatabaseFactory.Object, EventLogger, 0, [USER_ID, USER_ID_2, 3], new MatchmakingBeatmapSelector([]));
 
             await Hub.JoinRoom(ROOM_ID);
             SetUserContext(ContextUser2);

--- a/osu.Server.Spectator.Tests/Matchmaking/RankedPlayMatchControllerTests.cs
+++ b/osu.Server.Spectator.Tests/Matchmaking/RankedPlayMatchControllerTests.cs
@@ -45,7 +45,7 @@ namespace osu.Server.Spectator.Tests.Matchmaking
         public async Task InitializeAsync()
         {
             using (var room = await Rooms.GetForUse(ROOM_ID, true))
-                room.Item = await MatchmakingQueueBackgroundService.InitialiseRoomAsync(ROOM_ID, HubContext, DatabaseFactory.Object, EventLogger, 0, [USER_ID, USER_ID_2]);
+                room.Item = await MatchmakingQueueBackgroundService.InitialiseRoomAsync(ROOM_ID, HubContext, DatabaseFactory.Object, EventLogger, 0, [USER_ID, USER_ID_2], new MatchmakingBeatmapSelector([]));
         }
 
         [Fact]

--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -688,7 +688,7 @@ namespace osu.Server.Spectator.Database
         {
             var connection = await getConnectionAsync();
 
-            return (await connection.QueryAsync<matchmaking_pool_beatmap>("SELECT p.*, b.checksum, b.difficultyrating FROM `matchmaking_pool_beatmaps` p "
+            return (await connection.QueryAsync<matchmaking_pool_beatmap>("SELECT p.*, b.playmode, b.checksum, b.difficultyrating FROM `matchmaking_pool_beatmaps` p "
                                                                           + "JOIN `osu_beatmaps` b ON p.beatmap_id = b.beatmap_id "
                                                                           + "WHERE p.pool_id = @PoolId", new
             {
@@ -710,7 +710,7 @@ namespace osu.Server.Spectator.Database
             // - Ranked status
             // - Between 1 and 4 minutes in length
             // - With the correct keymode (if mania)
-            return (await connection.QueryAsync<database_beatmap>("SELECT b.beatmap_id, b.checksum, b.difficultyrating FROM `osu_beatmaps` b "
+            return (await connection.QueryAsync<database_beatmap>("SELECT b.beatmap_id, b.playmode, b.checksum, b.difficultyrating FROM `osu_beatmaps` b "
                                                                   + "JOIN `osu_beatmapsets` s ON s.beatmapset_id = b.beatmapset_id "
                                                                   + "WHERE s.track_id IS NOT NULL "
                                                                   + "AND b.playmode = @RulesetId "

--- a/osu.Server.Spectator/Database/Models/matchmaking_pool_beatmap.cs
+++ b/osu.Server.Spectator/Database/Models/matchmaking_pool_beatmap.cs
@@ -5,6 +5,9 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+using osu.Game.Online.API;
+using osu.Game.Online.Rooms;
 
 namespace osu.Server.Spectator.Database.Models
 {
@@ -20,8 +23,18 @@ namespace osu.Server.Spectator.Database.Models
         public int selection_count { get; set; }
 
         // osu_beatmaps
+        public ushort playmode { get; set; }
         public string? checksum { get; set; }
         public double difficultyrating { get; set; }
+
+        public MultiplayerPlaylistItem ToPlaylistItem() => new MultiplayerPlaylistItem
+        {
+            BeatmapID = beatmap_id,
+            BeatmapChecksum = checksum!,
+            RulesetID = playmode,
+            StarRating = difficultyrating,
+            RequiredMods = JsonConvert.DeserializeObject<APIMod[]>(mods ?? string.Empty) ?? [],
+        };
 
         public bool Equals(matchmaking_pool_beatmap? other)
             => other != null

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/IMatchmakingMatchController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/IMatchmakingMatchController.cs
@@ -8,7 +8,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking
 {
     public interface IMatchmakingMatchController
     {
-        Task Initialise(uint poolId, MatchmakingQueueUser[] users);
+        Task Initialise(uint poolId, MatchmakingQueueUser[] users, MatchmakingBeatmapSelector beatmapSelector);
 
         void SkipToNextStage(out Task countdownTask);
     }

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
@@ -68,7 +68,6 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
             }
 
             room.MatchState = State;
-            room.Settings.PlaylistItemId = room.Playlist[Random.Shared.Next(0, room.Playlist.Count)].ID;
         }
 
         async Task IMatchController.Initialise()
@@ -77,9 +76,21 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
             await GotoStage(RankedPlayStage.WaitForJoin);
         }
 
-        Task IMatchmakingMatchController.Initialise(uint poolId, MatchmakingQueueUser[] users)
+        async Task IMatchmakingMatchController.Initialise(uint poolId, MatchmakingQueueUser[] users, MatchmakingBeatmapSelector beatmapSelector)
         {
             PoolId = poolId;
+
+            using (var db = DbFactory.GetInstance())
+            {
+                foreach (var beatmap in beatmapSelector.GetAppropriateBeatmaps(users.Select(u => u.Rating).ToArray()))
+                {
+                    MultiplayerPlaylistItem item = beatmap.ToPlaylistItem();
+                    item.ID = await db.AddPlaylistItemAsync(new multiplayer_playlist_item(Room.RoomID, item));
+                    Room.Playlist.Add(item);
+                }
+            }
+
+            Room.Settings.PlaylistItemId = Room.Playlist[Random.Shared.Next(0, Room.Playlist.Count)].ID;
 
             foreach (var user in users)
             {
@@ -88,8 +99,6 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
                     Rating = (int)Math.Round(user.Rating.Mu)
                 };
             }
-
-            return Task.CompletedTask;
         }
 
         Task<bool> IMatchController.UserCanJoin(int userId)

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
@@ -33,9 +33,19 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
         public readonly MultiplayerEventLogger EventLogger;
         public readonly RankedPlayRoomState State;
 
+        /// <summary>
+        /// The card that was last activated by any user.
+        /// </summary>
         public RankedPlayCardItem? LastActivatedCard { get; private set; }
 
+        /// <summary>
+        /// Mapping of cards to their associated effect.
+        /// </summary>
         private readonly Dictionary<RankedPlayCardItem, MultiplayerPlaylistItem> cardToEffectMap = [];
+
+        /// <summary>
+        /// Cards that may be drawn from the deck.
+        /// </summary>
         private readonly List<RankedPlayCardItem> deck = [];
 
         private RankedPlayStageImplementation stageImplementation;
@@ -240,6 +250,9 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
 
             await Hub.NotifyRankedPlayCardRevealed(Room, null, card, effect);
             await Hub.NotifyRankedPlayCardPlayed(Room, card);
+
+            // Todo: If we ever have cards with non-"play beatmap" effects, then
+            //       this is the first responder to perform any relevant actions.
 
             using (var db = DbFactory.GetInstance())
             {

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
@@ -27,23 +27,16 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
 
         public uint PoolId { get; private set; }
 
-        /// <summary>
-        /// Mapping from cards to their associated playlist item.
-        /// </summary>
-        public readonly Dictionary<RankedPlayCardItem, MultiplayerPlaylistItem> ItemMap = [];
-
-        /// <summary>
-        /// Mapping from playlist items to their associated card.
-        /// </summary>
-        public readonly Dictionary<long, RankedPlayCardItem> CardMap = [];
-
         public readonly ServerMultiplayerRoom Room;
         public readonly IMultiplayerHubContext Hub;
         public readonly IDatabaseFactory DbFactory;
         public readonly MultiplayerEventLogger EventLogger;
         public readonly RankedPlayRoomState State;
 
+        private readonly Dictionary<RankedPlayCardItem, MultiplayerPlaylistItem> cardToEffectMap = [];
+        private readonly Dictionary<MultiplayerPlaylistItem, RankedPlayCardItem> effectToCardMap = [];
         private readonly List<RankedPlayCardItem> deck = [];
+
         private RankedPlayStageImplementation stageImplementation;
 
         public RankedPlayMatchController(ServerMultiplayerRoom room, IMultiplayerHubContext hub, IDatabaseFactory dbFactory, MultiplayerEventLogger eventLogger)
@@ -54,18 +47,6 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
             EventLogger = eventLogger;
             State = new RankedPlayRoomState();
             stageImplementation = new EmptyStage(this);
-
-            if (room.Playlist.Count < DECK_SIZE)
-                throw new InvalidOperationException($"There should be at least {DECK_SIZE} items in the playlist!");
-
-            foreach (var item in Random.Shared.GetItems(room.Playlist.ToArray(), room.Playlist.Count))
-            {
-                var card = new RankedPlayCardItem();
-                deck.Add(card);
-
-                ItemMap[card] = item;
-                CardMap[item.ID] = card;
-            }
 
             room.MatchState = State;
         }
@@ -80,18 +61,37 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
         {
             PoolId = poolId;
 
-            using (var db = DbFactory.GetInstance())
+            // Build the deck.
+            matchmaking_pool_beatmap[] beatmaps = beatmapSelector.GetAppropriateBeatmaps(users.Select(u => u.Rating).ToArray());
+
+            if (beatmaps.Length < DECK_SIZE)
+                throw new InvalidOperationException($"There should be at least {DECK_SIZE} beatmaps, but only {beatmaps.Length} were selected.");
+
+            int effectId = 0;
+
+            foreach (var beatmap in Random.Shared.GetItems(beatmaps, beatmaps.Length))
             {
-                foreach (var beatmap in beatmapSelector.GetAppropriateBeatmaps(users.Select(u => u.Rating).ToArray()))
-                {
-                    MultiplayerPlaylistItem item = beatmap.ToPlaylistItem();
-                    item.ID = await db.AddPlaylistItemAsync(new multiplayer_playlist_item(Room.RoomID, item));
-                    Room.Playlist.Add(item);
-                }
+                var card = new RankedPlayCardItem();
+                var effect = beatmap.ToPlaylistItem();
+                effect.ID = ++effectId;
+
+                cardToEffectMap[card] = effect;
+                effectToCardMap[effect] = card;
+
+                deck.Add(card);
             }
 
-            Room.Settings.PlaylistItemId = Room.Playlist[Random.Shared.Next(0, Room.Playlist.Count)].ID;
+            // Create an initial playlist item for the room. Clients require this to operate correctly.
+            using (var db = DbFactory.GetInstance())
+            {
+                MultiplayerPlaylistItem initialItem = new MultiplayerPlaylistItem();
+                initialItem.ID = await db.AddPlaylistItemAsync(new multiplayer_playlist_item(Room.RoomID, initialItem));
 
+                Room.Playlist.Add(initialItem);
+                Room.Settings.PlaylistItemId = initialItem.ID;
+            }
+
+            // Create the user states.
             foreach (var user in users)
             {
                 State.Users[user.UserId] = new RankedPlayUserInfo
@@ -115,9 +115,12 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
         {
             using (var db = DbFactory.GetInstance())
             {
-                // Expire and let clients know that the current item has finished.
                 await db.MarkPlaylistItemAsPlayedAsync(Room.RoomID, CurrentItem.ID);
-                Room.Playlist[Room.Playlist.IndexOf(CurrentItem)] = (await db.GetPlaylistItemAsync(Room.RoomID, CurrentItem.ID)).ToMultiplayerPlaylistItem();
+
+                multiplayer_playlist_item newItem = await db.GetPlaylistItemAsync(Room.RoomID, CurrentItem.ID);
+                CurrentItem.Expired = newItem.expired;
+                CurrentItem.PlayedAt = newItem.played_at;
+
                 await Hub.NotifyPlaylistItemChanged(Room, CurrentItem, true);
             }
 
@@ -212,7 +215,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
             {
                 State.Users[userId].Hand.Add(card);
                 await Hub.NotifyRankedPlayCardAdded(Room, userId, card);
-                await Hub.NotifyRankedPlayCardRevealed(Room, userId, card, ItemMap[card]);
+                await Hub.NotifyRankedPlayCardRevealed(Room, userId, card, LookupEffect(card));
             }
 
             await Hub.NotifyMatchRoomStateChanged(Room);
@@ -234,9 +237,53 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
             await Hub.NotifyMatchRoomStateChanged(Room);
         }
 
-        public async Task RemoveCards(int userId, long[] playlistItemIds)
+        /// <summary>
+        /// Activates the card, placing its effect on the room.
+        /// </summary>
+        public async Task ActivateCard(RankedPlayCardItem card)
         {
-            await RemoveCards(userId, playlistItemIds.Select(i => CardMap[i]).ToArray());
+            MultiplayerPlaylistItem effect = LookupEffect(card);
+
+            await Hub.NotifyRankedPlayCardRevealed(Room, null, card, effect);
+            await Hub.NotifyRankedPlayCardPlayed(Room, card);
+
+            using (var db = DbFactory.GetInstance())
+            {
+                if (CurrentItem.Expired)
+                {
+                    effect.ID = await db.AddPlaylistItemAsync(new multiplayer_playlist_item(Room.RoomID, effect));
+
+                    Room.Playlist.Add(effect);
+                    await Hub.NotifyPlaylistItemAdded(Room, effect);
+                }
+                else
+                {
+                    effect.ID = CurrentItem.ID;
+
+                    Room.Playlist[Room.Playlist.IndexOf(CurrentItem)] = effect;
+                    await db.UpdatePlaylistItemAsync(new multiplayer_playlist_item(Room.RoomID, effect));
+                    await Hub.NotifyPlaylistItemChanged(Room, effect, true);
+                }
+            }
+
+            Room.Settings.PlaylistItemId = effect.ID;
+            await Hub.NotifySettingsChanged(Room, true);
+        }
+
+        /// <summary>
+        /// Looks up the effect for a given card.
+        /// </summary>
+        public MultiplayerPlaylistItem LookupEffect(RankedPlayCardItem card)
+        {
+            return cardToEffectMap[card];
+        }
+
+        /// <summary>
+        /// Looks up the card for a given effect.
+        /// </summary>
+        public RankedPlayCardItem LookupCard(MultiplayerPlaylistItem effect)
+        {
+            return effectToCardMap[effect];
         }
 
         public MatchStartedEventDetail GetMatchDetails() => new MatchStartedEventDetail

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/RankedPlayMatchController.cs
@@ -33,8 +33,9 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
         public readonly MultiplayerEventLogger EventLogger;
         public readonly RankedPlayRoomState State;
 
+        public RankedPlayCardItem? LastActivatedCard { get; private set; }
+
         private readonly Dictionary<RankedPlayCardItem, MultiplayerPlaylistItem> cardToEffectMap = [];
-        private readonly Dictionary<MultiplayerPlaylistItem, RankedPlayCardItem> effectToCardMap = [];
         private readonly List<RankedPlayCardItem> deck = [];
 
         private RankedPlayStageImplementation stageImplementation;
@@ -67,17 +68,10 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
             if (beatmaps.Length < DECK_SIZE)
                 throw new InvalidOperationException($"There should be at least {DECK_SIZE} beatmaps, but only {beatmaps.Length} were selected.");
 
-            int effectId = 0;
-
             foreach (var beatmap in Random.Shared.GetItems(beatmaps, beatmaps.Length))
             {
                 var card = new RankedPlayCardItem();
-                var effect = beatmap.ToPlaylistItem();
-                effect.ID = ++effectId;
-
-                cardToEffectMap[card] = effect;
-                effectToCardMap[effect] = card;
-
+                cardToEffectMap[card] = beatmap.ToPlaylistItem();
                 deck.Add(card);
             }
 
@@ -215,7 +209,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
             {
                 State.Users[userId].Hand.Add(card);
                 await Hub.NotifyRankedPlayCardAdded(Room, userId, card);
-                await Hub.NotifyRankedPlayCardRevealed(Room, userId, card, LookupEffect(card));
+                await Hub.NotifyRankedPlayCardRevealed(Room, userId, card, cardToEffectMap[card]);
             }
 
             await Hub.NotifyMatchRoomStateChanged(Room);
@@ -242,7 +236,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
         /// </summary>
         public async Task ActivateCard(RankedPlayCardItem card)
         {
-            MultiplayerPlaylistItem effect = LookupEffect(card);
+            MultiplayerPlaylistItem effect = cardToEffectMap[card];
 
             await Hub.NotifyRankedPlayCardRevealed(Room, null, card, effect);
             await Hub.NotifyRankedPlayCardPlayed(Room, card);
@@ -268,22 +262,8 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay
 
             Room.Settings.PlaylistItemId = effect.ID;
             await Hub.NotifySettingsChanged(Room, true);
-        }
 
-        /// <summary>
-        /// Looks up the effect for a given card.
-        /// </summary>
-        public MultiplayerPlaylistItem LookupEffect(RankedPlayCardItem card)
-        {
-            return cardToEffectMap[card];
-        }
-
-        /// <summary>
-        /// Looks up the card for a given effect.
-        /// </summary>
-        public RankedPlayCardItem LookupCard(MultiplayerPlaylistItem effect)
-        {
-            return effectToCardMap[effect];
+            LastActivatedCard = card;
         }
 
         public MatchStartedEventDetail GetMatchDetails() => new MatchStartedEventDetail

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/CardPlayStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/CardPlayStage.cs
@@ -29,13 +29,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
 
         protected override async Task Finish()
         {
-            playedCard ??= State.ActiveUser.Hand.First();
-            await Hub.NotifyRankedPlayCardRevealed(Room, null, playedCard, Controller.ItemMap[playedCard]);
-            await Hub.NotifyRankedPlayCardPlayed(Room, playedCard);
-
-            Room.Settings.PlaylistItemId = Controller.ItemMap[playedCard].ID;
-            await Hub.NotifySettingsChanged(Room, true);
-
+            await Controller.ActivateCard(playedCard ?? State.ActiveUser.Hand.First());
             await Controller.GotoStage(RankedPlayStage.FinishCardPlay);
         }
 

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/GameplayStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/GameplayStage.cs
@@ -25,7 +25,7 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
 
         protected override async Task Finish()
         {
-            await Controller.RemoveCards(State.ActiveUserId, [Room.Settings.PlaylistItemId]);
+            await Controller.RemoveCards(State.ActiveUserId, [Controller.LookupCard(Controller.CurrentItem)]);
             await Controller.GotoStage(RankedPlayStage.Results);
         }
 

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/GameplayStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/GameplayStage.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
 
@@ -25,7 +26,9 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
 
         protected override async Task Finish()
         {
-            await Controller.RemoveCards(State.ActiveUserId, [Controller.LookupCard(Controller.CurrentItem)]);
+            Debug.Assert(Controller.LastActivatedCard != null);
+
+            await Controller.RemoveCards(State.ActiveUserId, [Controller.LastActivatedCard]);
             await Controller.GotoStage(RankedPlayStage.Results);
         }
 


### PR DESCRIPTION
This also implements the concept of "effects". Every card has an associated effect that is activated when the card itself is activated.

In order to hide playlist items from the rooms, I'm inserting a dummy playlist item when the room is created, which is required for clients to behave correctly (`CurrentPlaylistItem` cannot be null). When a card is played, I'm either updating that dummy playlist item (if it's not expired), or adding a new playlist item.

This ends up being quite database-efficient as well, as compared to the existing quick play implementation which dumps 20 playlist items in the database every time.