### PR TITLE
Track user Elo history

### DIFF
--- a/osu.Server.Spectator/Database/DatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/DatabaseAccess.cs
@@ -774,6 +774,23 @@ namespace osu.Server.Spectator.Database
             });
         }
 
+        public async Task InsertUserEloHistoryEntry(ulong roomId, uint poolId, uint userId, uint opponentId, matchmaking_room_result result, int eloBefore, int eloAfter)
+        {
+            var connection = await getConnectionAsync();
+
+            await connection.ExecuteAsync("INSERT INTO `matchmaking_user_elo_history` (room_id, pool_id, user_id, opponent_id, result, elo_before, elo_after, created_at, updated_at) "
+                                          + "VALUES (@RoomId, @PoolId, @UserId, @OpponentId, @Result, @EloBefore, @EloAfter, NOW(), NOW())", new
+            {
+                RoomId = roomId,
+                PoolId = poolId,
+                UserId = userId,
+                OpponentId = opponentId,
+                Result = result.ToString(),
+                EloBefore = eloBefore,
+                EloAfter = eloAfter
+            });
+        }
+
         public void Dispose()
         {
             openConnection?.Dispose();

--- a/osu.Server.Spectator/Database/IDatabaseAccess.cs
+++ b/osu.Server.Spectator/Database/IDatabaseAccess.cs
@@ -282,5 +282,7 @@ namespace osu.Server.Spectator.Database
         Task<matchmaking_user_stats?> GetMatchmakingUserStatsAsync(int userId, uint poolId);
 
         Task UpdateMatchmakingUserStatsAsync(matchmaking_user_stats stats);
+
+        Task InsertUserEloHistoryEntry(ulong roomId, uint poolId, uint userId, uint opponentId, matchmaking_room_result result, int eloBefore, int eloAfter);
     }
 }

--- a/osu.Server.Spectator/Database/Models/matchmaking_room_result.cs
+++ b/osu.Server.Spectator/Database/Models/matchmaking_room_result.cs
@@ -1,0 +1,17 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+// ReSharper disable InconsistentNaming (matches database table)
+
+using System;
+
+namespace osu.Server.Spectator.Database.Models
+{
+    [Serializable]
+    public enum matchmaking_room_result
+    {
+        win,
+        loss,
+        draw
+    }
+}

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/EndedStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/EndedStage.cs
@@ -69,6 +69,24 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
 
                 for (int i = 0; i < stats.Count; i++)
                 {
+                    matchmaking_room_result result;
+
+                    if (State.WinningUserId == null)
+                        result = matchmaking_room_result.draw;
+                    else if (State.WinningUserId == stats[i].user_id)
+                        result = matchmaking_room_result.win;
+                    else
+                        result = matchmaking_room_result.loss;
+
+                    await db.InsertUserEloHistoryEntry(
+                        (ulong)Room.RoomID,
+                        Controller.PoolId,
+                        stats[i].user_id,
+                        stats.First(u => u.user_id != stats[i].user_id).user_id,
+                        result,
+                        (int)Math.Round(stats[i].EloData.Rating.Mu),
+                        (int)Math.Round(newRatings[i].Mu));
+
                     stats[i].EloData.ContestCount++;
                     stats[i].EloData.Rating = new EloRating(newRatings[i].Mu, newRatings[i].Sigma);
                     await db.UpdateMatchmakingUserStatsAsync(stats[i]);

--- a/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/EndedStage.cs
+++ b/osu.Server.Spectator/Hubs/Multiplayer/Matchmaking/RankedPlay/Stages/EndedStage.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using OpenSkillSharp.Models;
 using OpenSkillSharp.Rating;
+using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
 using osu.Server.Spectator.Database.Models;
 using osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.Elo;
@@ -98,6 +99,12 @@ namespace osu.Server.Spectator.Hubs.Multiplayer.Matchmaking.RankedPlay.Stages
 
         protected override Task Finish()
         {
+            return Task.CompletedTask;
+        }
+
+        public override Task HandleUserLeft(MultiplayerRoomUser user)
+        {
+            // The match is over, no need to kill users.
             return Task.CompletedTask;
         }
     }


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-web/pull/12798

Also contains a fix for the ended stage being re-entered when users leave the room, something I noticed along the way that triggers multiple insertions into the table.